### PR TITLE
Replaced Task.Result with Task.GetAwaiter().GetResult()

### DIFF
--- a/src/DShop.Services.Customers/Handlers/Products/ProductDeletedHandler.cs
+++ b/src/DShop.Services.Customers/Handlers/Products/ProductDeletedHandler.cs
@@ -23,7 +23,7 @@ namespace DShop.Services.Customers.Handlers.Products
         {
             await _productsRepository.DeleteAsync(@event.Id);
             var carts = await _cartsRepository.GetAllWithProduct(@event.Id)
-                .ContinueWith(t => t.Result.ToList());
+                .ContinueWith(t => t.GetAwaiter().GetResult().ToList());
             foreach (var cart in carts)
             {
                 cart.DeleteProduct(@event.Id);

--- a/src/DShop.Services.Customers/Handlers/Products/ProductUpdatedHandler.cs
+++ b/src/DShop.Services.Customers/Handlers/Products/ProductUpdatedHandler.cs
@@ -25,7 +25,7 @@ namespace DShop.Services.Customers.Handlers.Products
             var product = new Product(@event.Id, @event.Name, @event.Price, @event.Quantity);
             await _productsRepository.UpdateAsync(product);
             var carts = await _cartsRepository.GetAllWithProduct(product.Id)
-                .ContinueWith(t => t.Result.ToList());
+                .ContinueWith(t => t.GetAwaiter().GetResult().ToList());
             foreach (var cart in carts)
             {
                 cart.UpdateProduct(product);


### PR DESCRIPTION
According to issue #19 we should use ``Task.GetAwaiter().GetResult()`` instead of ``Task.Result``.